### PR TITLE
Fix：修正由于文件名增加'.dump'后缀后导致的sublime无法渲染的问题

### DIFF
--- a/sublime_gbk.py
+++ b/sublime_gbk.py
@@ -21,8 +21,9 @@ def gbk2utf8(view):
         tmp_view = window.open_file(tmp_file)
 
         if not tmp_view:
-            window.open_file(tmp_file)
+            tmp_view = window.open_file(tmp_file)
         
+        tmp_view.set_syntax_file(view.settings().get('syntax'))
         window.focus_view(view)
         window.run_command('close')
         window.focus_view(tmp_view)


### PR DESCRIPTION
修正打开'.dump'临时文件导致sublime无法渲染代码的问题
